### PR TITLE
🐛 Add filter 'construction permit'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Add filter 'construction permit' to total_signed_contracts
+
 ## 0.0.1
 
 - initial model

--- a/models/marts/campaigns.sql
+++ b/models/marts/campaigns.sql
@@ -76,7 +76,8 @@ campaign_summary as (
             'end installation',
             'legal registration',
             'legalization',
-            'warranty payment'
+            'warranty payment',
+            'construction permit'
         )) as total_signed_contracts,
         count(*) filter (
             where projects.status = 'signature'


### PR DESCRIPTION
 Co-authored-by: javikalsan <jcalzadosanchez@gmail.com>
 Co-authored-by: Joana Figueira <joana.figueira@somenergia.coop>

## Description

'Construction permit' total does not shown in total_signed_contracts.

## Changes

Add filter 'construction permit' to total_signed_contracts

## Observations

## Please, review

- List of things authors emphasize to review

## How to check the new features

## Deploy notes


